### PR TITLE
fix: Custom gas token check with EigenDA enabled

### DIFF
--- a/src/__snapshots__/prepareChainConfig.unit.test.ts.snap
+++ b/src/__snapshots__/prepareChainConfig.unit.test.ts.snap
@@ -5,9 +5,10 @@ exports[`creates chain config with custom params 1`] = `
   "arbitrum": {
     "AllowDebugPrecompiles": true,
     "DataAvailabilityCommittee": true,
+    "EigenDA": true,
     "EnableArbOS": false,
     "GenesisBlockNum": 1,
-    "InitialArbOSVersion": 20,
+    "InitialArbOSVersion": 32,
     "InitialChainOwner": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
     "MaxCodeSize": 40960,
     "MaxInitCodeSize": 81920,
@@ -39,9 +40,10 @@ exports[`creates chain config with defaults 1`] = `
   "arbitrum": {
     "AllowDebugPrecompiles": false,
     "DataAvailabilityCommittee": false,
+    "EigenDA": true,
     "EnableArbOS": true,
     "GenesisBlockNum": 0,
-    "InitialArbOSVersion": 20,
+    "InitialArbOSVersion": 32,
     "InitialChainOwner": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
     "MaxCodeSize": 24576,
     "MaxInitCodeSize": 49152,

--- a/src/createRollupPrepareTransactionRequest.ts
+++ b/src/createRollupPrepareTransactionRequest.ts
@@ -8,6 +8,7 @@ import { validateParentChain } from './types/ParentChain';
 import { isCustomFeeTokenAddress } from './utils/isCustomFeeTokenAddress';
 import { ChainConfig } from './types/ChainConfig';
 import { isAnyTrustChainConfig } from './utils/isAnyTrustChainConfig';
+import { isEigenDAChainConfig } from './utils/isEigenDAChainConfig';
 import { getRollupCreatorAddress } from './utils/getters';
 import { fetchDecimals } from './utils/erc20';
 import { TransactionRequestGasOverrides, applyPercentIncrease } from './utils/gasOverrides';
@@ -58,9 +59,9 @@ export async function createRollupPrepareTransactionRequest<TChain extends Chain
 
   if (isCustomFeeTokenAddress(params.nativeToken)) {
     // custom fee token is only allowed for anytrust chains
-    if (!isAnyTrustChainConfig(chainConfig)) {
+    if (!isAnyTrustChainConfig(chainConfig) && !isEigenDAChainConfig(chainConfig)) {
       throw new Error(
-        `"params.nativeToken" can only be used on AnyTrust chains. Set "arbitrum.DataAvailabilityCommittee" to "true" in the chain config.`,
+        `"params.nativeToken" can only be used on AnyTrust or EigenDA chains. Set "arbitrum.DataAvailabilityCommittee" to "true" or "arbitrum.EigenDA" to "true" in the chain config.`,
       );
     }
 

--- a/src/createRollupPrepareTransactionRequest.ts
+++ b/src/createRollupPrepareTransactionRequest.ts
@@ -58,7 +58,7 @@ export async function createRollupPrepareTransactionRequest<TChain extends Chain
   const chainConfig: ChainConfig = JSON.parse(params.config.chainConfig);
 
   if (isCustomFeeTokenAddress(params.nativeToken)) {
-    // custom fee token is only allowed for anytrust chains
+    // custom fee token is only allowed for anytrust and eigenda chains
     if (!isAnyTrustChainConfig(chainConfig) && !isEigenDAChainConfig(chainConfig)) {
       throw new Error(
         `"params.nativeToken" can only be used on AnyTrust or EigenDA chains. Set "arbitrum.DataAvailabilityCommittee" to "true" or "arbitrum.EigenDA" to "true" in the chain config.`,

--- a/src/utils/isEigenDAChainConfig.ts
+++ b/src/utils/isEigenDAChainConfig.ts
@@ -1,0 +1,5 @@
+import { ChainConfig } from '../types/ChainConfig';
+
+export function isEigenDAChainConfig(chainConfig: ChainConfig) {
+  return chainConfig.arbitrum.EigenDA;
+}


### PR DESCRIPTION
Extends `createRollupPrepareTransactionRequest` invariant which enforces that custom gas token support can only work with anytrust chains to also include eigenda in check. Logic cases have been tested and node config tests are slightly updated. 